### PR TITLE
fix: raising not impl fails when extra args

### DIFF
--- a/ddispatch/_dispatch.py
+++ b/ddispatch/_dispatch.py
@@ -62,5 +62,5 @@ else:
             return generic
 
 
-def _raise_not_implemented(dispatch_on):
+def _raise_not_implemented(dispatch_on, *args, **kwargs):
     raise TypeError(f"No dispatch implementation for type: {type(dispatch_on)}")

--- a/ddispatch/tests/test_dispatch.py
+++ b/ddispatch/tests/test_dispatch.py
@@ -94,3 +94,13 @@ def test_dispatch_uses_final_docstring():
         return x * 2
 
     assert f.__doc__ == "This is the final docstring."
+
+def test_dispatch_not_impl():
+    @dispatch
+    def f(x: int) -> int:
+        return x + 1
+
+    with pytest.raises(TypeError) as exc_info:
+        f(1.0, 2, z=3)
+
+    assert str(exc_info.value) == "No dispatch implementation for type: <class 'float'>"


### PR DESCRIPTION
Trying to call a generic with a unsupported first arg AND additional arguments should raise a not implemented error, but the raising of the error was screwing up (since it didn't expect additional arguments!)